### PR TITLE
Use pidfd instead of pid to stop job

### DIFF
--- a/cmd/telepilotd/main.go
+++ b/cmd/telepilotd/main.go
@@ -47,10 +47,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	grpcServer := grpc.NewServer(
-		grpc.Creds(credentials.NewTLS(tlsConfig)),
-		grpc.UnaryInterceptor(s.UnaryMiddleware),
-		grpc.StreamInterceptor(s.StreamMiddleware),
+	grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)),
+		grpc.UnaryInterceptor(s.UnaryMiddleware), grpc.StreamInterceptor(s.StreamMiddleware),
 	)
 	pb.RegisterTelePilotServiceServer(grpcServer, s)
 

--- a/pkg/jobmanager/job.go
+++ b/pkg/jobmanager/job.go
@@ -74,6 +74,8 @@ func newJob(owner, cmd string, args []string) *Job {
 
 		// Make use of clone3 cgroup arg.
 		UseCgroupFD: true,
+
+		PidFD: new(int),
 	}
 
 	return j

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/google/uuid"
 
@@ -69,9 +69,9 @@ func (jm *JobManager) StopJob(id uuid.UUID) error {
 	if j.cmd.Process != nil {
 		// Send the KILL to the process group, not just the process to avoid orphans.
 		// NOTE: This is POSIX compliant.
-		if err := syscall.Kill(-j.cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		if err := j.cmd.Process.Kill(); err != nil {
 			j.mu.Unlock()
-			if errors.Is(err, syscall.ESRCH) {
+			if errors.Is(err, os.ErrProcessDone) {
 				// If the process died as we were about to stop it, nothing to do.
 				// Don't set the status as stopped as it exited on it's own.
 				// This is an unavoidable "race" as we don't control the child process,


### PR DESCRIPTION
This allows to remove the underlying race between wait and kill.